### PR TITLE
fix token parsing; content that is being signed should be copied verbatim instead of regenerated.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -8,6 +8,15 @@ func NewErrNoTicket() error {
 func (e ErrNoTicket) Error() string {
 	return string(e)
 }
+type ErrNoSig string
+
+func NewErrNoSig() error {
+	return ErrNoSig("No signature found in ticke")
+}
+func (e ErrNoSig) Error() string {
+	return string(e)
+}
+
 
 type ErrNoSSl string
 

--- a/model.go
+++ b/model.go
@@ -2,7 +2,6 @@ package pubtkt
 
 import (
 	"fmt"
-	"strings"
 	"time"
 )
 
@@ -76,35 +75,15 @@ type Ticket struct {
 	Bauth       string    `mapstructure:"bauth"`
 	Validuntil  time.Time `mapstructure:"validuntil"`
 	Graceperiod time.Time `mapstructure:"graceperiod"`
+	// raw data "before signature" ; splitting and restructuring data is error-prone
+	SigData     string
 	Tokens      []string  `mapstructure:"tokens"`
 	Udata       string    `mapstructure:"udata"`
 	Sig         string    `mapstructure:"sig"`
 }
 
 func (t Ticket) DataString() string {
-	data := make([]string, 0)
-	if t.Uid != "" {
-		data = append(data, fmt.Sprintf("%s=%s", "uid", t.Uid))
-	}
-	if t.Cip != "" {
-		data = append(data, fmt.Sprintf("%s=%s", "cip", t.Cip))
-	}
-	if t.Bauth != "" {
-		data = append(data, fmt.Sprintf("%s=%s", "bauth", t.Bauth))
-	}
-	if !t.Validuntil.IsZero() {
-		data = append(data, fmt.Sprintf("%s=%d", "validuntil", t.Validuntil.Unix()))
-	}
-	if !t.Graceperiod.IsZero() {
-		data = append(data, fmt.Sprintf("%s=%d", "graceperiod", t.Graceperiod.Unix()))
-	}
-	if len(t.Tokens) != 0 {
-		data = append(data, fmt.Sprintf("%s=%s", "tokens", strings.Join(t.Tokens, ",")))
-	}
-	if t.Udata != "" {
-		data = append(data, fmt.Sprintf("%s=%s", "udata", t.Udata))
-	}
-	return strings.Join(data, ";")
+	return t.SigData
 }
 func (t Ticket) String() string {
 	data := t.DataString()

--- a/parser.go
+++ b/parser.go
@@ -15,7 +15,13 @@ func ParseTicket(ticketStr string) (*Ticket, error) {
 		DecodeHook: ticketDecoderHook,
 		Result:     ticket,
 	}
-
+	// apache module just splits ticket by sig; do the same
+	ticketParts := strings.SplitN(ticketStr,";sig=",2);
+	if len(ticketParts) == 2 {
+		ticket.SigData = ticketParts[0]
+	}  else {
+		return nil, NewErrNoSig()
+	}
 	decoder, err := mapstructure.NewDecoder(&config)
 	if err != nil {
 		return nil, err

--- a/pubtkt.go
+++ b/pubtkt.go
@@ -210,7 +210,6 @@ func (a AuthPubTktImpl) verifyRsaSignature(ticket *Ticket) error {
 	}
 	hash.Write([]byte(ticket.DataString()))
 	digest := hash.Sum(nil)
-
 	err = rsa.VerifyPKCS1v15(pub, cryptoHash, digest, ds)
 	if err != nil {
 		return NewErrSigNotValid(err)


### PR DESCRIPTION
Currently the signed data is re-generated from already parsed ticket before validating signature, which causes problems in some cases.

Current logic will also break if there will be a field re-order or a new field will be added. Data that is supposed to be verified should be always copied verbatim

On getting `uid=xani;validuntil=1555161753;graceperiod=1555158153;tokens=efi;udata=;` (which is what will the PHP example generate) the current implementation of DataString() will generate 
`uid=xani;validuntil=1555161753;graceperiod=1555158153;tokens=efi;` which will fail the validation

For example, the PHP will [happily generate empty udata](https://github.com/manuelkasper/mod_auth_pubtkt/blob/master/php-login/pubtkt.inc#L54), meanwhile this package will just [not put it in the output](https://github.com/orange-cloudfoundry/go-auth-pubtkt/blob/master/model.go#L104)

This is how apache splits "the data to verify" and "the sig of the data"

https://github.com/manuelkasper/mod_auth_pubtkt/blob/master/src/mod_auth_pubtkt.c#L647

and reference signing uses same logic, basically "generate the string, sign it, then append the signature to it" 